### PR TITLE
Don't create settings.json if there is no pack.mcmeta

### DIFF
--- a/src/theme_change.ts
+++ b/src/theme_change.ts
@@ -26,9 +26,6 @@ export function checkPackMcmeta() {
 			if (packMcmetaExists) {
 				vscode.workspace.getConfiguration('workbench')
 					.update('iconTheme', 'mc-dp-icons', vscode.ConfigurationTarget.Workspace);
-			} else if (defaultIconTheme) {
-				vscode.workspace.getConfiguration('workbench')
-					.update('iconTheme', defaultIconTheme, vscode.ConfigurationTarget.Workspace);
 			}
 		});
 	}


### PR DESCRIPTION
I found it quite annoying that the extension would create a `.vscode` folder and `settings.json` file in every project I opened with VSCode, so I made it only create it when `pack.mcmeta` exists. That way it will default to whatever file icon the user chooses anyway.